### PR TITLE
improve shortcat.applescript

### DIFF
--- a/shortcat/shortcat.applescript
+++ b/shortcat/shortcat.applescript
@@ -1,18 +1,7 @@
-set the clipboard to "{query}"
 tell application "System Events"
-	keystroke space using {command down, shift down}
-end tell
-
-set len to count (the clipboard)
-set theString to the clipboard
-
-repeat with n from 1 to len
-		tell application "System Events"
-			delay 0.002
-			keystroke (character n of theString)
-		end tell
-end repeat
-
-tell application "System Events"
-	keystroke return
+    keystroke space using {command down, shift down}
+    delay 0.01
+    keystroke "{query}"
+    delay 0.01
+    keystroke return
 end tell


### PR DESCRIPTION
- don't use clipboard
- keystroke {query} with one command

I think it's faster and more reliable as well.
